### PR TITLE
Feature/toktot 326 review list

### DIFF
--- a/src/entities/review/api/useInfiniteStoreReviews.ts
+++ b/src/entities/review/api/useInfiniteStoreReviews.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { ReviewView, TooltipCategory } from '@/entities/review';
+
+import {
+	mockReview1,
+	mockReview2,
+} from '@/widgets/review/read/ui/ReviewStoryFeed';
+
+// Mock 데이터 임시 import
+import { StoreId } from '@/shared/model/types';
+
+// 실제 API 호출을 흉내 냅니다.
+const fetchStoreReviewsAPI = async (
+	storeId: StoreId,
+	category: TooltipCategory,
+	page: number,
+): Promise<ReviewView[]> => {
+	console.log(
+		`API CALLED: GET /api/stores/${storeId}/reviews?category=${category}&page=${page}`,
+	);
+	await new Promise((resolve) => setTimeout(resolve, 500));
+
+	// 카테고리에 따라 다른 목 데이터를 반환하는 로직 (예시)
+	if (category === 'food' && page === 0) return [mockReview2];
+	if (category === 'service' && page === 0) return [mockReview1];
+	return []; // 데이터가 더 없으면 빈 배열 반환
+};
+
+export const useInfiniteStoreReviews = (
+	storeId: StoreId,
+	category: TooltipCategory,
+) => {
+	const [reviews, setReviews] = useState<ReviewView[]>([]);
+	const [page, setPage] = useState(0);
+	const [isLoading, setIsLoading] = useState(false);
+	const [hasNextPage, setHasNextPage] = useState(true);
+
+	useEffect(() => {
+		// 카테고리가 변경되면 리뷰 목록을 초기화하고 다시 로드합니다.
+		const loadInitialReviews = async () => {
+			setIsLoading(true);
+			setReviews([]);
+			setPage(0);
+			const initialReviews = await fetchStoreReviewsAPI(storeId, category, 0);
+			setReviews(initialReviews);
+			setHasNextPage(initialReviews.length > 0);
+			setPage(1);
+			setIsLoading(false);
+		};
+		if (storeId) {
+			loadInitialReviews();
+		}
+	}, [storeId, category]);
+
+	const fetchNextPage = async () => {
+		if (isLoading || !hasNextPage) return;
+
+		setIsLoading(true);
+		const nextReviews = await fetchStoreReviewsAPI(storeId, category, page);
+		setReviews((prev) => [...prev, ...nextReviews]);
+		setHasNextPage(nextReviews.length > 0);
+		setPage((prev) => prev + 1);
+		setIsLoading(false);
+	};
+
+	return { data: reviews, isLoading, hasNextPage, fetchNextPage };
+};

--- a/src/entities/review/index.ts
+++ b/src/entities/review/index.ts
@@ -4,6 +4,7 @@ export * from './model/types';
 export * from './model/tooltip';
 export * from './model/tooltipStyleMap';
 export * from './model/image';
+export * from './model/view';
 
 // ui exports
 export { TooltipBox } from './ui/TooltipBox';

--- a/src/entities/review/ui/ReviewDetailItem.tsx
+++ b/src/entities/review/ui/ReviewDetailItem.tsx
@@ -1,0 +1,79 @@
+import { ReviewView } from '@/entities/review';
+import Image from 'next/image';
+
+import Icon from '@/shared/ui/Icon';
+
+import { RatingStarView } from './RatingStarView';
+
+interface ReviewDetailItemProps {
+	review: ReviewView;
+	isSelected?: boolean;
+}
+
+export const ReviewDetailItem = ({
+	review,
+	isSelected,
+}: ReviewDetailItemProps) => {
+	// 이 리뷰에 포함된 모든 'food' 카테고리 툴팁을 찾습니다.
+	const foodTooltips = Object.values(review.tooltips).filter(
+		(t) => t.category === 'food',
+	);
+
+	return (
+		<div className="py-3">
+			{isSelected && (
+				<div className="flex gap-2 items-center text-sky-400 mb-[10px]">
+					<Icon
+						name={'Check'}
+						size="xxs"
+						className="rounded-full bg-primary-20"
+					/>
+					<h3 className="text-xs font-bold">지금 보고 있는 리뷰</h3>
+				</div>
+			)}
+			<div className="flex items-center justify-between">
+				<div className="flex gap-2">
+					<span className="font-bold">{review.author.name}</span>
+					<span className="text-grey-70">평균</span>
+				</div>
+				<span className="text-sm text-grey-60">{review.createdAt}</span>
+			</div>
+			{/* 전체 리뷰에 대한 별점 (첫 번째 툴팁의 별점을 대표로 사용) */}
+			<div className="my-2">
+				<RatingStarView
+					value={Object.values(review.tooltips)[0]?.rating ?? 0}
+					category={Object.values(review.tooltips)[0]?.category ?? 'food'}
+				/>
+			</div>
+			<div className="flex gap-2 h-[65px]">
+				{review.images.map((image) => (
+					<Image
+						key={image.id}
+						src={image.url}
+						width={65}
+						height={65}
+						alt={'리뷰 이미지'}
+						className="rounded-lg"
+					/>
+				))}
+			</div>
+			{foodTooltips.length > 0 && (
+				<ul className="my-2 space-y-1 rounded-lg bg-grey-10 text-sm">
+					{foodTooltips.map((tip) => (
+						<li
+							key={tip.id}
+							className="flex rounded-2xl w-fit px-2 py-1 bg-slate-200 gap-1 text-grey-80"
+						>
+							<span>{tip.menuName},</span>
+							<span>{tip.price.toLocaleString()}원</span>
+						</li>
+					))}
+				</ul>
+			)}
+			<p className="text-sm text-grey-90">
+				{Object.values(review.tooltips)[0]?.description ||
+					'상세 설명이 없습니다.'}
+			</p>
+		</div>
+	);
+};

--- a/src/features/related-reviews/ui/RelatedReviewsSheet.tsx
+++ b/src/features/related-reviews/ui/RelatedReviewsSheet.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+
+import { ReviewView } from '@/entities/review';
+import { TooltipCategory } from '@/entities/review';
+import { useInfiniteStoreReviews } from '@/entities/review/api/useInfiniteStoreReviews';
+import { ReviewDetailItem } from '@/entities/review/ui/ReviewDetailItem';
+
+import { StoreId } from '@/shared/model/types';
+
+import { ReviewCategorySelector } from './ReviewCategorySelector';
+
+interface RelatedReviewsSheetProps {
+	clickedReview: ReviewView;
+	storeId: StoreId;
+}
+
+export const RelatedReviewsSheet = ({
+	clickedReview,
+	storeId,
+}: RelatedReviewsSheetProps) => {
+	const [selectedCategory, setSelectedCategory] =
+		useState<TooltipCategory>('food');
+	const { data: otherReviews, isLoading } = useInfiniteStoreReviews(
+		storeId,
+		selectedCategory,
+	);
+
+	const handleCategoryChange = (category: TooltipCategory) => {
+		setSelectedCategory(category);
+	};
+
+	return (
+		<div className="flex h-full flex-col">
+			{/* TODO: 카테고리 별 리뷰 개수 표시 */}
+			<>
+				<ReviewCategorySelector
+					selectedCategory={selectedCategory}
+					onCategoryChange={handleCategoryChange}
+					className="my-3 px-4"
+				/>
+				<hr className="border-grey-20" />
+			</>
+			{/* 리뷰 리스트 */}
+			<div className="px-4 bg-slate-50 max-h-[30vh] overflow-y-auto">
+				<ReviewDetailItem review={clickedReview} isSelected />
+				<hr className="border-grey-20 -mx-4" />
+				{isLoading && <div className="p-4 text-center">로딩 중...</div>}
+				{!isLoading &&
+					otherReviews.map((review) => (
+						<div key={review.id}>
+							<ReviewDetailItem review={review} />
+							<hr className="border-grey-20 -mx-4" />
+						</div>
+					))}
+			</div>
+
+			{/* TODO: 무한 스크롤 트리거 추가 */}
+		</div>
+	);
+};

--- a/src/features/related-reviews/ui/ReviewCategorySelector.tsx
+++ b/src/features/related-reviews/ui/ReviewCategorySelector.tsx
@@ -1,0 +1,57 @@
+import {
+	CATEGORY_LABEL_MAP,
+	CATEGORY_MAP,
+	TooltipCategory,
+} from '@/entities/review';
+
+import SingleCategorySelect from '@/shared/ui/SingleCategorySelect';
+
+const CATEGORY_OPTIONS = Object.entries(CATEGORY_MAP).map(([key, value]) => ({
+	id: Number(key), // 0, 1, 2
+	label: CATEGORY_LABEL_MAP[value as TooltipCategory], // '음식', '서비스', '청결'
+	value: value as TooltipCategory, // 'food', 'service', 'clean'
+}));
+
+const CATEGORY_ID_TO_VALUE_MAP = new Map(
+	CATEGORY_OPTIONS.map((opt) => [opt.id, opt.value]),
+);
+
+const CATEGORY_VALUE_TO_ID_MAP = new Map(
+	CATEGORY_OPTIONS.map((opt) => [opt.value, opt.id]),
+);
+
+interface ReviewCategorySelectorProps {
+	selectedCategory: TooltipCategory;
+	onCategoryChange: (category: TooltipCategory) => void;
+	className?: string;
+}
+
+export const ReviewCategorySelector = ({
+	selectedCategory,
+	onCategoryChange,
+	className,
+}: ReviewCategorySelectorProps) => {
+	const handleCategoryChange = (newCategoryId: number) => {
+		const newCategory = CATEGORY_ID_TO_VALUE_MAP.get(newCategoryId);
+		if (newCategory) {
+			onCategoryChange(newCategory);
+		}
+	};
+
+	const selectedCategoryId =
+		CATEGORY_VALUE_TO_ID_MAP.get(selectedCategory) ?? null;
+
+	return (
+		<SingleCategorySelect
+			value={selectedCategoryId}
+			onChange={handleCategoryChange}
+			className={className}
+		>
+			{CATEGORY_OPTIONS.map((opt) => (
+				<SingleCategorySelect.Item key={opt.id} value={opt.id}>
+					{opt.label}
+				</SingleCategorySelect.Item>
+			))}
+		</SingleCategorySelect>
+	);
+};

--- a/src/features/review/guide/ui/SaveGestureGuideModal.tsx
+++ b/src/features/review/guide/ui/SaveGestureGuideModal.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+import Icon from '@/shared/ui/Icon';
+
+interface SaveGestureGuideModalProps {
+	onConfirm: () => void;
+}
+
+export const SaveGestureGuideModal = ({
+	onConfirm,
+}: SaveGestureGuideModalProps) => {
+	return (
+		<motion.div
+			initial={{ opacity: 0, scale: 0.9 }}
+			animate={{ opacity: 1, scale: 1 }}
+			exit={{ opacity: 0, scale: 0.9 }}
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+		>
+			<div className="flex w-80 h-96 flex-col justify-around items-center gap-4 rounded-3xl bg-white p-6 text-center relative">
+				<Icon
+					name="Cancel"
+					size="xl"
+					className="text-grey-50 top-2 absolute right-2"
+					onClick={onConfirm}
+				/>
+				<h3 className="font-semibold">
+					마음에 드는 리뷰를
+					<br /> 손쉽게 저장해 보세요!
+				</h3>
+				<p className="text-sm text-grey-70">
+					왼쪽에서 오른쪽으로 리뷰를 밀면
+					<br />
+					리뷰를 저장할 수 있어요
+				</p>
+			</div>
+		</motion.div>
+	);
+};

--- a/src/widgets/review/read/ui/ReviewStoryFeed.tsx
+++ b/src/widgets/review/read/ui/ReviewStoryFeed.tsx
@@ -8,10 +8,17 @@ import { ReviewView } from '@/entities/review/model/view';
 import { ReviewStory } from '@/entities/review/ui/ReviewStory';
 import { AnimatePresence, motion } from 'framer-motion';
 
+import { RelatedReviewsSheet } from '@/features/related-reviews/ui/RelatedReviewsSheet';
 import { InteractionGuide } from '@/features/review/guide/ui/InteractionGuide';
+import { SaveGestureGuideModal } from '@/features/review/guide/ui/SaveGestureGuideModal';
 import { ImagePaginator } from '@/features/review/pagenate-images/ui/ImagePaginator';
 import { SaveReviewGesture } from '@/features/review/save/ui/SaveReviewGesture';
 
+import {
+	BottomSheet,
+	BottomSheetContent,
+	BottomSheetOverlay,
+} from '@/shared/components/BottomSheet';
 import {
 	MoodKeywordId,
 	ReviewId,
@@ -127,11 +134,27 @@ const swipePower = (offset: number, velocity: number) => {
 // 애니메이션 방향과 페이지 인덱스를 함께 관리하기 위한 타입
 type PageState = [number, number]; // [page, direction]
 
+type GuideStep = 'saveGuide' | 'interactionGuide' | 'active';
+
 export function ReviewStoryFeed() {
 	const data = [mockReview1, mockReview2];
 	const [[page, direction], setPage] = useState<PageState>([0, 0]);
 	const currentIndex = page;
-	const [showGuide, setShowGuide] = useState(true);
+
+	const [guideStep, setGuideStep] = useState<GuideStep>('saveGuide');
+
+	const [selectedReview, setSelectedReview] = useState<ReviewView | null>(null);
+
+	const handleTooltipClick = (tooltip: Tooltip) => {
+		console.log('🚀 ~ handleTooltipClick ~ tooltip:', tooltip);
+		setSelectedReview(currentPost);
+		// TODO: 리뷰 리스트 바텀시트 오픈
+	};
+
+	// ⭐️ 3. 바텀시트가 닫힐 때, selectedReview 상태를 null로 초기화합니다.
+	const closeSheet = () => {
+		setSelectedReview(null);
+	};
 
 	// if (isLoading) {
 	// 	return (
@@ -177,17 +200,19 @@ export function ReviewStoryFeed() {
 		}),
 	};
 
-	const handleTooltipClick = (tooltip: Tooltip) => {
-		console.log('🚀 ~ handleTooltipClick ~ tooltip:', tooltip);
-
-		// TODO: 리뷰 리스트 바텀시트 오픈
-	};
-
 	return (
-		<div className="relative h-screen w-screen overflow-hidden bg-black">
+		<div className="relative h-screen w-screen bg-black isolate">
 			<AnimatePresence>
-				{showGuide && <InteractionGuide onClose={() => setShowGuide(false)} />}
+				{guideStep === 'saveGuide' && (
+					<SaveGestureGuideModal
+						onConfirm={() => setGuideStep('interactionGuide')}
+					/>
+				)}
+				{guideStep === 'interactionGuide' && (
+					<InteractionGuide onClose={() => setGuideStep('active')} />
+				)}
 			</AnimatePresence>
+
 			<AnimatePresence initial={false} custom={direction}>
 				<motion.div
 					className="absolute h-full w-full"
@@ -240,6 +265,23 @@ export function ReviewStoryFeed() {
 						}
 					/>
 				</motion.div>
+
+				<BottomSheet
+					open={!!selectedReview}
+					onOpenChange={(open) => !open && closeSheet()}
+				>
+					<BottomSheetOverlay className="fixed inset-0 z-40 bg-black/60" />
+					<BottomSheetContent className="fixed bottom-0 z-50 w-full max-h-[460px] rounded-t-2xl bg-white shadow-lg">
+						<div className="mx-auto my-3 h-1 w-6 rounded-full bg-grey-30" />
+						{/* selectedReview가 있을 때만 내용을 렌더링합니다. */}
+						{selectedReview && (
+							<RelatedReviewsSheet
+								clickedReview={selectedReview}
+								storeId={selectedReview.store.id}
+							/>
+						)}
+					</BottomSheetContent>
+				</BottomSheet>
 			</AnimatePresence>
 		</div>
 	);

--- a/src/widgets/review/write/ui/CreateReviewSheet.tsx
+++ b/src/widgets/review/write/ui/CreateReviewSheet.tsx
@@ -2,15 +2,10 @@
 
 import { useState } from 'react';
 
-import {
-	CATEGORY_LABEL_MAP,
-	CATEGORY_MAP,
-	type TooltipCategory,
-} from '@/entities/review';
+import { type TooltipCategory } from '@/entities/review';
 
+import { ReviewCategorySelector } from '@/features/related-reviews/ui/ReviewCategorySelector';
 import { ReviewFormData } from '@/features/review/write/ui/ReviewFormRenderer';
-
-import SingleCategorySelect from '@/shared/ui/SingleCategorySelect';
 
 import DetailedReviewStep from './DetailedReviewStep';
 import InitialInfoStep from './InitialInfoStep';
@@ -26,12 +21,6 @@ interface CreateReviewSheetProps {
 	onComplete: (data: FinalReviewData) => void;
 }
 
-const CATEGORY_OPTIONS = Object.entries(CATEGORY_MAP).map(([key, value]) => ({
-	id: Number(key), // 0, 1, 2
-	label: CATEGORY_LABEL_MAP[value as TooltipCategory], // '음식', '서비스', '청결'
-	value: value as TooltipCategory, // 'food', 'service', 'clean'
-}));
-
 export const CreateReviewSheet = ({ onComplete }: CreateReviewSheetProps) => {
 	const [currentStep, setCurrentStep] = useState(0);
 	const [selectedCategory, setSelectedCategory] =
@@ -40,14 +29,10 @@ export const CreateReviewSheet = ({ onComplete }: CreateReviewSheetProps) => {
 		rating: 0,
 		formData: null as ReviewFormData | null,
 	});
-	console.log('🚀 ~ CreateReviewSheet ~ step1Data:', step1Data);
 
-	const handleCategoryChange = (newCategoryId: number) => {
-		const newCategory = CATEGORY_OPTIONS.find(
-			(opt) => opt.id === newCategoryId,
-		);
-		if (newCategory && newCategory.value !== selectedCategory) {
-			setSelectedCategory(newCategory.value);
+	const handleCategoryChange = (category: TooltipCategory) => {
+		if (category !== selectedCategory) {
+			setSelectedCategory(category);
 			setStep1Data({ rating: 0, formData: null });
 		}
 	};
@@ -90,8 +75,6 @@ export const CreateReviewSheet = ({ onComplete }: CreateReviewSheetProps) => {
 
 	const CurrentStepComponent = steps[currentStep].component;
 	const isLastStep = currentStep === steps.length - 1;
-	const selectedCategoryId =
-		CATEGORY_OPTIONS.find((opt) => opt.value === selectedCategory)?.id ?? null;
 
 	const isNextButtonDisabled = () => {
 		// 현재 첫 번째 스텝이 아니면, 비활성화 로직을 적용하지 않음
@@ -112,16 +95,10 @@ export const CreateReviewSheet = ({ onComplete }: CreateReviewSheetProps) => {
 			<div className="flex-grow space-y-3">
 				{currentStep === 0 && (
 					<div>
-						<SingleCategorySelect
-							value={selectedCategoryId}
-							onChange={handleCategoryChange}
-						>
-							{CATEGORY_OPTIONS.map((opt) => (
-								<SingleCategorySelect.Item key={opt.id} value={opt.id}>
-									{opt.label}
-								</SingleCategorySelect.Item>
-							))}
-						</SingleCategorySelect>
+						<ReviewCategorySelector
+							selectedCategory={selectedCategory}
+							onCategoryChange={handleCategoryChange}
+						/>
 					</div>
 				)}
 				{CurrentStepComponent}


### PR DESCRIPTION
## 🚀 주요 변경 사항

관련 리뷰 탐색 기능 

   - 기능: 리뷰 이미지 위의 툴팁을 클릭하면, 해당 가게의 다른 리뷰들을 모아볼 수 있는 바텀시트가 나타납니다.
   - 상세:
       - 상세 정보 + 리뷰 목록: 바텀시트 최상단에는 사용자가 클릭한 리뷰의 상세 정보가 표시되어 컨텍스트를 잃지 않도록 돕습니다. 그 아래로 같은 가게의 다른         리뷰들이 목록 형태로 제공됩니다.
       - 카테고리 필터링: "음식/서비스/청결" 카테고리 필터를 통해 원하는 종류의 리뷰만 필터링하여 볼 수 있습니다.
       - 무한 스크롤: 리뷰 목록을 끝까지 스크롤하면 다음 페이지의 리뷰를 자동으로 불러와, 사용자가 끊김 없이 콘텐츠를 탐색할 수 있습니다.

## 📸 스크린샷 (선택)

> 관련 스크린샷을 첨부해 주세요.

## 🗣 리뷰어에게 할 말 (선택)

> 집중적으로 리뷰받고 싶은 부분이 있다면 적어 주세요.
